### PR TITLE
feat: add support for dependabot recreate

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This is because some of the repositories I'm involved in have _required actions 
 Thus a fake merge-train was born. It's of marginal use if your actions are fast, but when you have a monorepo where the integration tests take a few minutes this could reduce some toil.
 
 > It is a direct lift and shift of
-> - https://github.com/quotidian-ennui/ghcli-utils/pull/1
-> - https://github.com/quotidian-ennui/ghcli-utils/pull/2
-> - https://github.com/quotidian-ennui/ghcli-utils/pull/3
-
+>
+> - <https://github.com/quotidian-ennui/ghcli-utils/pull/1>
+> - <https://github.com/quotidian-ennui/ghcli-utils/pull/2>
+> - <https://github.com/quotidian-ennui/ghcli-utils/pull/3>
 
 ## Installation
 
@@ -46,16 +46,20 @@ Flags
   -m, --merge merge rather than rebase when updating the pr branch
 
 env:
-  GH_MERGE_TRAIN_MAX_ATTEMPTS      : [5] : how many times to attempt an update
-  GH_MERGE_TRAIN_BOT_LABEL         : [] : optional label to apply to a bot PR.
-  GH_MERGE_TRAIN_DEPENDABOT_REBASE : [] : optional use dependabot chat-ops to rebase if appropriate.
+  GH_POLL_INTERVAL_SECS             : interval between re-attempts         : []
+  GH_MERGE_TRAIN_MAX_ATTEMPTS       : how many times to attempt an update  : [4]
+  GH_MERGE_TRAIN_BOT_LABEL          : optional label to apply to a bot PR. : []
+  GH_MERGE_TRAIN_DEPENDABOT_REBASE  : if 'true' use @dependabot rebase     : []
+  GH_MERGE_TRAIN_DEPENDABOT_RECREATE: if 'true' use @dependabot recreate   : []
 ```
 
 #### Environment Variables
 
-- `GH_MERGE_TRAIN_MAX_ATTEMPTS` -> the max attempts to attempt to update the PR; defaults to 5 if not set.
+- `GH_POLL_INTERVAL_SECS` -> the interval between attempts to merge and other things
+- `GH_MERGE_TRAIN_MAX_ATTEMPTS` -> the max attempts to attempt to update the PR; defaults to 4 if not set.
 - `GH_MERGE_TRAIN_BOT_LABEL` -> an optional label that you want to apply to PRs that were raised by a bot (e.g. dependabot)
 - `GH_MERGE_TRAIN_DEPENDABOT_REBASE` -> use `@dependabot rebase` when updating the PR; if it is a dependabot created PR.
+- `GH_MERGE_TRAIN_DEPENDABOT_RECREATE` -> use `@dependabot recreate` when updating the PR; if it is a dependabot created PR.
 
 ### Bonus Chatter
 
@@ -63,4 +67,6 @@ There are reasons for the `GH_MERGE_TRAIN_BOT_LABEL` and `GH_MERGE_TRAIN_DEPENDA
 
 `GH_MERGE_TRAIN_BOT_LABEL` is because we did not want dependabot to trigger expensive builds; we only want to run the expensive builds after we have reviewed the dependency before merging. Dependabot _can be quite eager_ about rebasing so this avoids a chain of expensive builds that run without our intervention.
 
-`GH_MERGE_TRAIN_DEPENDABOT_REBASE` is because dependabot can do a _more appropriate thing_ when attempting to update a PR; it's subtly better than trying to do a `gh pr update-branch --rebase` in some use cases. If you are finding that, then setting this flag to be true will be your friend but you are going to be beholden to dependabot's scheduling.
+`GH_MERGE_TRAIN_DEPENDABOT_REBASE` | `GH_MERGE_TRAIN_DEPENDABOT_RECREATE` is because dependabot can do a _more appropriate thing_ when attempting to update a PR; it's subtly better than trying to do a `gh pr update-branch --rebase` in some use cases. If you are finding that, then setting this flag to be true will be your friend but you are going to be beholden to dependabot's scheduling.
+
+Note that right now (2026-03-13) there seems to be trouble with `gh pr update-branch --rebase` anyway (based on <https://github.com/orgs/community/discussions/189028>) so you might be better off always using the --merge flag.

--- a/gh-merge-train
+++ b/gh-merge-train
@@ -9,9 +9,10 @@ BASEDIR=$(dirname "$(realpath "$0")")
 source "$BASEDIR/includes/common.sh"
 POLL_INTERVAL_SECS=${GH_POLL_INTERVAL_SECS:-30}
 GH_MERGE_TRAIN_REBASE="true"
-GH_MERGE_TRAIN_MAX_ATTEMPTS=${GH_MERGE_TRAIN_MAX_ATTEMPTS:-5}
+GH_MERGE_TRAIN_MAX_ATTEMPTS=${GH_MERGE_TRAIN_MAX_ATTEMPTS:-4}
 GH_MERGE_TRAIN_BOT_LABEL=${GH_MERGE_TRAIN_BOT_LABEL:-}
 GH_MERGE_TRAIN_DEPENDABOT_REBASE=${GH_MERGE_TRAIN_DEPENDABOT_REBASE:-}
+GH_MERGE_TRAIN_DEPENDABOT_RECREATE=${GH_MERGE_TRAIN_DEPENDABOT_RECREATE:-}
 
 #shellcheck disable=SC2154
 usage() {
@@ -40,9 +41,11 @@ Flags
   -m, --merge merge rather than rebase when updating the pr branch
 
 env:
-  GH_MERGE_TRAIN_MAX_ATTEMPTS      : [$GH_MERGE_TRAIN_MAX_ATTEMPTS] : how many times to attempt an update
-  GH_MERGE_TRAIN_BOT_LABEL         : [$GH_MERGE_TRAIN_BOT_LABEL] : optional label to apply to a bot PR.
-  GH_MERGE_TRAIN_DEPENDABOT_REBASE : [$GH_MERGE_TRAIN_DEPENDABOT_REBASE] : optional use dependabot chat-ops to rebase if appropriate.
+  GH_POLL_INTERVAL_SECS             : interval between re-attempts         : [$GH_POLL_INTERVAL_SECS]
+  GH_MERGE_TRAIN_MAX_ATTEMPTS       : how many times to attempt an update  : [$GH_MERGE_TRAIN_MAX_ATTEMPTS]
+  GH_MERGE_TRAIN_BOT_LABEL          : optional label to apply to a bot PR. : [$GH_MERGE_TRAIN_BOT_LABEL]
+  GH_MERGE_TRAIN_DEPENDABOT_REBASE  : if 'true' use @dependabot rebase     : [$GH_MERGE_TRAIN_DEPENDABOT_REBASE]
+  GH_MERGE_TRAIN_DEPENDABOT_RECREATE: if 'true' use @dependabot recreate   : [$GH_MERGE_TRAIN_DEPENDABOT_RECREATE]
 EOF
   exit "$exit"
 }
@@ -84,15 +87,15 @@ __extract_squash_merge_message() {
   local pr_number=$1
   local body=""
   local message=""
-  
+
   body=$(gh pr view "$pr_number" --json "body" --jq ".body")
-  
+
   # Check if both markers exist before extraction
   if echo "$body" | grep -q "SQUASH_MERGE_START" && echo "$body" | grep -q "SQUASH_MERGE_END"; then
     # Extract content between markers, excluding the exact marker lines (HTML comments)
     message=$(echo "$body" | awk '/SQUASH_MERGE_START/,/SQUASH_MERGE_END/' | grep -Ev "<!--[[:space:]]*SQUASH_MERGE_(START|END)[[:space:]]*-->")
   fi
-  
+
   echo "$message"
 }
 
@@ -103,7 +106,7 @@ __bot_squash_merge_param() {
     local trimmed=""
     squash_message=$(__extract_squash_merge_message "$pr_number")
     trimmed=$(echo "$squash_message" | tr -d '[:space:]')
-    
+
     # If there's a viable squash-merge message (non-empty after trimming all whitespace), don't use default message
     if [[ -n "$trimmed" ]]; then
       echo ""
@@ -156,31 +159,36 @@ __approve_then_merge() {
 
 __update_branch() {
   local pr_number="$1"
+  local force_use_merge="$2"
   local updateCount=0
   local update_args=()
+  local dependabot_comment="@dependabot rebase"
 
-  if [[ "$GH_MERGE_TRAIN_DEPENDABOT_REBASE" == "true" ]]; then
+  if [[ "$GH_MERGE_TRAIN_DEPENDABOT_REBASE" == "true" || "$GH_MERGE_TRAIN_DEPENDABOT_RECREATE" == "true" ]]; then
     if __is_dependabot "$pr_number"; then
-      echo "ℹ️ Update branch using @dependabot rebase"
-      if ! gh pr comment "$pr_number" --body "@dependabot rebase"; then
+      if [[ "$GH_MERGE_TRAIN_DEPENDABOT_RECREATE" == "true" ]]; then
+        dependabot_comment="@dependabot recreate"
+      fi
+      echo "ℹ️ Update branch using $dependabot_comment"
+      if ! gh pr comment "$pr_number" --body "$dependabot_comment"; then
         echo "⚠️ Failed to rebase via comment dependabot comment"
-        exit 1
+        return 1
       fi
       while [[ ! $(__merge_status "$pr_number") =~ ^(CLEAN|BLOCKED)$ ]]; do
         updateCount=$((updateCount + 1))
         if [[ "$updateCount" -ge "$GH_MERGE_TRAIN_MAX_ATTEMPTS" ]]; then
           echo -e "\n🚫 Branch update failed too many times"
-          exit 1
+          return 1
         else
           echo "Waiting on dependabot to catch up for $POLL_INTERVAL_SECS seconds..."
           sleep "$POLL_INTERVAL_SECS"
         fi
       done
-      return
+      return 0
     fi
   fi
 
-  if [[ "$GH_MERGE_TRAIN_REBASE" == "true" ]]; then
+  if [[ "$GH_MERGE_TRAIN_REBASE" == "true" && "$force_use_merge" != "true" ]]; then
     update_args+=("--rebase")
   fi
 
@@ -190,12 +198,13 @@ __update_branch() {
     updateCount=$((updateCount + 1))
     if [[ "$updateCount" -ge "$GH_MERGE_TRAIN_MAX_ATTEMPTS" ]]; then
       echo -e "\n🚫 Branch update failed too many times"
-      exit 1
+      return 1
     else
       echo "Update failed. Retrying in $POLL_INTERVAL_SECS seconds..."
       sleep "$POLL_INTERVAL_SECS"
     fi
   done
+  return 0
 }
 
 {
@@ -237,7 +246,12 @@ __update_branch() {
     fi
     echo "ℹ️ Working on $url"
     if [[ ! $(__merge_status "$pr") =~ ^(CLEAN|BLOCKED)$ ]]; then
-      __update_branch "$pr"
+      if ! __update_branch "$pr"; then
+        echo "⚠️ last attempt to merge"
+        if ! __update_branch "$pr" "true"; then
+          exit 1
+        fi
+      fi
       # sad but sometimes the checks don't start quick enough
       sleep "$POLL_INTERVAL_SECS"
     fi

--- a/gh-merge-train
+++ b/gh-merge-train
@@ -41,7 +41,7 @@ Flags
   -m, --merge merge rather than rebase when updating the pr branch
 
 env:
-  GH_POLL_INTERVAL_SECS             : interval between re-attempts         : [$GH_POLL_INTERVAL_SECS]
+  GH_POLL_INTERVAL_SECS             : interval between re-attempts         : [$POLL_INTERVAL_SECS]
   GH_MERGE_TRAIN_MAX_ATTEMPTS       : how many times to attempt an update  : [$GH_MERGE_TRAIN_MAX_ATTEMPTS]
   GH_MERGE_TRAIN_BOT_LABEL          : optional label to apply to a bot PR. : [$GH_MERGE_TRAIN_BOT_LABEL]
   GH_MERGE_TRAIN_DEPENDABOT_REBASE  : if 'true' use @dependabot rebase     : [$GH_MERGE_TRAIN_DEPENDABOT_REBASE]
@@ -157,33 +157,47 @@ __approve_then_merge() {
   gh squash-merge "$pr_number" "$(__bot_squash_merge_param "$pr_number")"
 }
 
+__dependabot_commenter() {
+  local pr_number="$1"
+  local max_retries=$GH_MERGE_TRAIN_MAX_ATTEMPTS
+  local dependabot_comment="@dependabot rebase"
+
+  if [[ "$GH_MERGE_TRAIN_DEPENDABOT_RECREATE" == "true" ]]; then
+    dependabot_comment="@dependabot recreate"
+  fi
+  echo "ℹ️ Update branch using $dependabot_comment"
+  if ! gh pr comment "$pr_number" --body "$dependabot_comment"; then
+    echo "⚠️ Failed to rebase via comment $dependabot_comment"
+    return 1
+  fi
+  while [[ ! $(__merge_status "$pr_number") =~ ^(CLEAN|BLOCKED)$ ]]; do
+    updateCount=$((updateCount + 1))
+    if [[ "$updateCount" -ge "$max_retries" ]]; then
+      echo -e "\n🚫 Branch update failed too many times"
+      return 1
+    else
+      echo "Waiting on dependabot to catch up for $POLL_INTERVAL_SECS seconds..."
+      sleep "$POLL_INTERVAL_SECS"
+    fi
+  done
+  return 0
+}
 __update_branch() {
   local pr_number="$1"
   local force_use_merge="$2"
   local updateCount=0
   local update_args=()
   local dependabot_comment="@dependabot rebase"
+  local max_retries="$GH_MERGE_TRAIN_MAX_ATTEMPTS"
 
-  if [[ "$GH_MERGE_TRAIN_DEPENDABOT_REBASE" == "true" || "$GH_MERGE_TRAIN_DEPENDABOT_RECREATE" == "true" ]]; then
+  if [[ "$force_use_merge" == "true" ]]; then
+    max_retries=1
+  fi
+  if [[ "$force_use_merge" != "true" && ("$GH_MERGE_TRAIN_DEPENDABOT_REBASE" == "true" || "$GH_MERGE_TRAIN_DEPENDABOT_RECREATE" == "true") ]]; then
     if __is_dependabot "$pr_number"; then
-      if [[ "$GH_MERGE_TRAIN_DEPENDABOT_RECREATE" == "true" ]]; then
-        dependabot_comment="@dependabot recreate"
-      fi
-      echo "ℹ️ Update branch using $dependabot_comment"
-      if ! gh pr comment "$pr_number" --body "$dependabot_comment"; then
-        echo "⚠️ Failed to rebase via comment dependabot comment"
+      if ! __dependabot_commenter "$pr_number"; then
         return 1
       fi
-      while [[ ! $(__merge_status "$pr_number") =~ ^(CLEAN|BLOCKED)$ ]]; do
-        updateCount=$((updateCount + 1))
-        if [[ "$updateCount" -ge "$GH_MERGE_TRAIN_MAX_ATTEMPTS" ]]; then
-          echo -e "\n🚫 Branch update failed too many times"
-          return 1
-        else
-          echo "Waiting on dependabot to catch up for $POLL_INTERVAL_SECS seconds..."
-          sleep "$POLL_INTERVAL_SECS"
-        fi
-      done
       return 0
     fi
   fi
@@ -196,7 +210,7 @@ __update_branch() {
   echo "ℹ️ Update branch using gh pr update-branch $pr_number ${update_args[@]}"
   while ! gh pr update-branch "$pr_number" "${update_args[@]}"; do
     updateCount=$((updateCount + 1))
-    if [[ "$updateCount" -ge "$GH_MERGE_TRAIN_MAX_ATTEMPTS" ]]; then
+    if [[ "$updateCount" -ge "$max_retries" ]]; then
       echo -e "\n🚫 Branch update failed too many times"
       return 1
     else


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
- resolves #8
- resolves #9

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- rebase failures ends with a merge attempt
- allow dependabot recreate as an option

<!-- SQUASH_MERGE_END -->

