### PR TITLE
feat: add retry_failed_jobs feature

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,9 @@
 - Explain the "why" behind recommendations.
 - Always prioritize security vulnerabilities and performance issues that could impact users.
 - Never suggest changes to improve readability.
+- Never suggest changes to comments based on grammar and spelling
 - Never suggest changes related to platform variants for GNU tooling.
+- Early termination of scripts based on unexpected inputs is acceptable and too much error checking is BAD.
 
 ## General Principles
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ Flags
   -m, --merge merge rather than rebase when updating the pr branch
 
 env:
-  GH_POLL_INTERVAL_SECS             : interval between re-attempts         : []
-  GH_MERGE_TRAIN_MAX_ATTEMPTS       : how many times to attempt an update  : [4]
-  GH_MERGE_TRAIN_BOT_LABEL          : optional label to apply to a bot PR. : []
-  GH_MERGE_TRAIN_DEPENDABOT_REBASE  : if 'true' use @dependabot rebase     : []
-  GH_MERGE_TRAIN_DEPENDABOT_RECREATE: if 'true' use @dependabot recreate   : []
+  GH_POLL_INTERVAL_SECS             : interval between re-attempts            : [30]
+  GH_MERGE_TRAIN_MAX_ATTEMPTS       : how many times to attempt an update     : [4]
+  GH_MERGE_TRAIN_BOT_LABEL          : optional label to apply to a bot PR.    : []
+  GH_MERGE_TRAIN_DEPENDABOT_REBASE  : if 'true' use @dependabot rebase        : []
+  GH_MERGE_TRAIN_DEPENDABOT_RECREATE: if 'true' use @dependabot recreate      : []
+  GH_MERGE_TRAIN_RETRY_FAILED_JOBS  : Because you have flaky jobs for reasons : [false]
 ```
 
 #### Environment Variables
@@ -60,6 +61,7 @@ env:
 - `GH_MERGE_TRAIN_BOT_LABEL` -> an optional label that you want to apply to PRs that were raised by a bot (e.g. dependabot)
 - `GH_MERGE_TRAIN_DEPENDABOT_REBASE` -> use `@dependabot rebase` when updating the PR; if it is a dependabot created PR.
 - `GH_MERGE_TRAIN_DEPENDABOT_RECREATE` -> use `@dependabot recreate` when updating the PR; if it is a dependabot created PR.
+- `GH_MERGE_TRAIN_RETRY_FAILED_JOBS` -> set to true to retry failed status checks in the PR once (and only once!)
 
 ### Bonus Chatter
 
@@ -70,3 +72,5 @@ There are reasons for the `GH_MERGE_TRAIN_BOT_LABEL` and `GH_MERGE_TRAIN_DEPENDA
 `GH_MERGE_TRAIN_DEPENDABOT_REBASE` | `GH_MERGE_TRAIN_DEPENDABOT_RECREATE` is because dependabot can do a _more appropriate thing_ when attempting to update a PR; it's subtly better than trying to do a `gh pr update-branch --rebase` in some use cases. If you are finding that, then setting this flag to be true will be your friend but you are going to be beholden to dependabot's scheduling.
 
 Note that right now (2026-03-13) there seems to be trouble with `gh pr update-branch --rebase` anyway (based on <https://github.com/orgs/community/discussions/189028>) so you might be better off always using the --merge flag.
+
+`GH_MERGE_TRAIN_RETRY_FAILED_JOBS` is because some projects appear to have flaky tests that don't always complete under the auspices of github. Setting this variable to be 'true' allows the failed jobs to be retried once via the `gh run rerun --job` command. It's intentional to only run once, if the tests are going to semi-reliably fail then it's indicative of a bigger problem anyway so you probably have some technical debt to fix the actions.

--- a/gh-merge-train
+++ b/gh-merge-train
@@ -13,6 +13,11 @@ GH_MERGE_TRAIN_MAX_ATTEMPTS=${GH_MERGE_TRAIN_MAX_ATTEMPTS:-4}
 GH_MERGE_TRAIN_BOT_LABEL=${GH_MERGE_TRAIN_BOT_LABEL:-}
 GH_MERGE_TRAIN_DEPENDABOT_REBASE=${GH_MERGE_TRAIN_DEPENDABOT_REBASE:-}
 GH_MERGE_TRAIN_DEPENDABOT_RECREATE=${GH_MERGE_TRAIN_DEPENDABOT_RECREATE:-}
+GH_MERGE_TRAIN_RETRY_FAILED_JOBS=${GH_MERGE_TRAIN_RETRY_FAILED_JOBS:-false}
+
+# Selects failed jobs from the status_rollup with some dodgy capturing
+# output to be {"runId":"24521981319","jobId":"71682061689"}
+JQ_FAILED_JOBS='.[] | select ( .conclusion=="FAILURE" ) | .detailsUrl | capture("/runs/(?<runId>[0-9]+)/job/(?<jobId>[0-9]+)")'
 
 #shellcheck disable=SC2154
 usage() {
@@ -41,13 +46,20 @@ Flags
   -m, --merge merge rather than rebase when updating the pr branch
 
 env:
-  GH_POLL_INTERVAL_SECS             : interval between re-attempts         : [$POLL_INTERVAL_SECS]
-  GH_MERGE_TRAIN_MAX_ATTEMPTS       : how many times to attempt an update  : [$GH_MERGE_TRAIN_MAX_ATTEMPTS]
-  GH_MERGE_TRAIN_BOT_LABEL          : optional label to apply to a bot PR. : [$GH_MERGE_TRAIN_BOT_LABEL]
-  GH_MERGE_TRAIN_DEPENDABOT_REBASE  : if 'true' use @dependabot rebase     : [$GH_MERGE_TRAIN_DEPENDABOT_REBASE]
-  GH_MERGE_TRAIN_DEPENDABOT_RECREATE: if 'true' use @dependabot recreate   : [$GH_MERGE_TRAIN_DEPENDABOT_RECREATE]
+  GH_POLL_INTERVAL_SECS             : interval between re-attempts            : [$POLL_INTERVAL_SECS]
+  GH_MERGE_TRAIN_MAX_ATTEMPTS       : how many times to attempt an update     : [$GH_MERGE_TRAIN_MAX_ATTEMPTS]
+  GH_MERGE_TRAIN_BOT_LABEL          : optional label to apply to a bot PR.    : [$GH_MERGE_TRAIN_BOT_LABEL]
+  GH_MERGE_TRAIN_DEPENDABOT_REBASE  : if 'true' use @dependabot rebase        : [$GH_MERGE_TRAIN_DEPENDABOT_REBASE]
+  GH_MERGE_TRAIN_DEPENDABOT_RECREATE: if 'true' use @dependabot recreate      : [$GH_MERGE_TRAIN_DEPENDABOT_RECREATE]
+  GH_MERGE_TRAIN_RETRY_FAILED_JOBS  : Because you have flaky jobs for reasons : [$GH_MERGE_TRAIN_RETRY_FAILED_JOBS]
 EOF
   exit "$exit"
+}
+
+__sleep() {
+  local msg="$1"
+  echo -e "$msg"
+  sleep "$POLL_INTERVAL_SECS"
 }
 
 __is_bot() {
@@ -128,9 +140,37 @@ __label_if_bot() {
   fi
 }
 
+__retry_failed_jobs() {
+  local pr_number="$1"
+  local runId
+  local jobId
+  local job_id_jsonlines=()
+
+  mapfile -t job_id_jsonlines < <(gh pr view "$pr_number" --json "statusCheckRollup" --jq '.statusCheckRollup' | jq -c "$JQ_FAILED_JOBS")
+  for jsonline in "${job_id_jsonlines[@]}"; do
+    runId=$(echo "$jsonline" | jq -r ".runId")
+    jobId=$(echo "$jsonline" | jq -r ".jobId")
+    echo "🔎 ... Retry $jobId in $runId"
+    gh run rerun --job "$jobId"
+  done
+}
+
+# Dodgy actions, retry them once
+# After that, fail. Dev should fix your damned actions!
+__wait_with_retry() {
+  local pr_number="$1"
+
+  if ! __wait_for_checks "$pr_number"; then
+    echo "🛟 ... PR Checks had failures, retry once"
+    __retry_failed_jobs "$pr_number"
+    __sleep "💤 ... Waiting for jobs to start"
+    __wait_for_checks "$pr_number"
+  fi
+}
+
 __wait_for_checks() {
   local pr_number="$1"
-  echo "🔎 ...waiting for checks to complete using gh pr checks"
+  echo "🔎 ... waiting for checks to complete using gh pr checks"
   gh pr checks "$pr_number" --watch --fail-fast --interval "$POLL_INTERVAL_SECS"
 }
 
@@ -176,12 +216,12 @@ __dependabot_commenter() {
       echo -e "\n🚫 Branch update failed too many times"
       return 1
     else
-      echo "Waiting on dependabot to catch up for $POLL_INTERVAL_SECS seconds..."
-      sleep "$POLL_INTERVAL_SECS"
+      __sleep "💤 Waiting on dependabot to catch up, $POLL_INTERVAL_SECS seconds..."
     fi
   done
   return 0
 }
+
 __update_branch() {
   local pr_number="$1"
   local force_use_merge="$2"
@@ -214,8 +254,7 @@ __update_branch() {
       echo -e "\n🚫 Branch update failed too many times"
       return 1
     else
-      echo "Update failed. Retrying in $POLL_INTERVAL_SECS seconds..."
-      sleep "$POLL_INTERVAL_SECS"
+      __sleep "⚠️ Update failed. Retrying in $POLL_INTERVAL_SECS seconds..."
     fi
   done
   return 0
@@ -250,7 +289,7 @@ __update_branch() {
 
   for pr in "$@"; do
     if [[ "$first" != "true" ]]; then
-      sleep "$POLL_INTERVAL_SECS"
+      __sleep "💤..."
     fi
     first="false"
     url="$(__pr_view_field url "$pr")"
@@ -267,10 +306,14 @@ __update_branch() {
         fi
       fi
       # sad but sometimes the checks don't start quick enough
-      sleep "$POLL_INTERVAL_SECS"
+      __sleep "💤... Waiting for checks to fire."
     fi
     __label_if_bot "$pr"
-    __wait_for_checks "$pr"
+    if [[ "$GH_MERGE_TRAIN_RETRY_FAILED_JOBS" == "true" ]]; then
+      __wait_with_retry "$pr"
+    else
+      __wait_for_checks "$pr"
+    fi
     __approve_then_merge "$pr"
   done
 }


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->
- Because you have a bunch of jobs that fail intermittently, because of reasons that are between you and your keyboard (and the language you've chosen to write code in).
- you're probably already using nick-fields/retry, but it's not enough; oh, it truly is a docker in docker, networking, the classic jenkins isn't a developer machine problem
- works on my machine eh?, shame on you.


## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- add retry_failed_jobs feature

<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->

```
export GH_MERGE_TRAIN_RETRY_FAILED_JOBS=true
gh merge-train 131
...
🔎 ...waiting for checks to complete using gh pr checks
Some checks were not successful
0 cancelled, 1 failing, 11 successful, 2 skipped, and 0 pending checks
...
🛟 ... PR Checks had failures, retry once
🔎 ... Retry 71691860902 in 24521981319
✓ Requested rerun of job 71691860902 on run 24521981319
🔎 ...waiting for checks to complete using gh pr checks
...
```

- of course, we could retry a set number of times (like MAX_RETRY_ATTEMPTS) but honestly, if it's gonna fail 4+ times, you should probably really fix those actions.