### PR TITLE
refactor: only add label if it exists

### DIFF
--- a/gh-merge-train
+++ b/gh-merge-train
@@ -131,12 +131,24 @@ __bot_squash_merge_param() {
 }
 
 __is_valid_label() {
-  local label_to_find="$1"
+  local pr_number="$1"
+  local label_to_find="$2"
   local found_label=""
-  found_label=$(gh label list --json "name" | jq -r --arg label "$label_to_find" -c '.[] | select (.name == $label) | .name')
-  if [[ "$found_label" == "$GH_MERGE_TRAIN_BOT_LABEL" ]]; then
+  local repo=""
+  local alt_repo_args=()
+
+  if [[ "$pr_number" =~ http* ]]; then
+    ## github URL, so strip it out.
+    repo="${pr_number##https://github.com/}"
+    repo="${repo%%/pull*}"
+    alt_repo_args+=("--repo")
+    alt_repo_args+=("$repo")
+  fi
+  found_label=$(gh label list "${alt_repo_args[@]}" --json "name" | jq -r --arg label "$label_to_find" -c '.[] | select (.name == $label) | .name')
+  if [[ "$found_label" == "$label_to_find" ]]; then
     return 0
   fi
+  echo "🏷️ label $label_to_find not found in repo for $pr_number"
   return 1
 }
 
@@ -152,7 +164,7 @@ __wait_if_skipped_jobs() {
 __label_if_bot() {
   local pr_number=$1
   if [[ -n "$GH_MERGE_TRAIN_BOT_LABEL" ]]; then
-    if __is_valid_label "$GH_MERGE_TRAIN_BOT_LABEL"; then
+    if __is_valid_label "$pr_number" "$GH_MERGE_TRAIN_BOT_LABEL"; then
       if __is_bot "$pr_number"; then
         echo "ℹ️ Applying label $GH_MERGE_TRAIN_BOT_LABEL"
         gh pr edit "$pr_number" --add-label "$GH_MERGE_TRAIN_BOT_LABEL"

--- a/gh-merge-train
+++ b/gh-merge-train
@@ -130,12 +130,35 @@ __bot_squash_merge_param() {
   fi
 }
 
+__is_valid_label() {
+  local label_to_find="$1"
+  local found_label=""
+  found_label=$(gh label list --json "name" | jq -r --arg label "$label_to_find" -c '.[] | select (.name == $label) | .name')
+  if [[ "$found_label" == "$GH_MERGE_TRAIN_BOT_LABEL" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+__wait_if_skipped_jobs() {
+  local pr_number=$1
+  local skipped_jobs=0
+  skipped_jobs=$(gh pr checks "$pr_number" --json "name,state" | jq -r -c '.[] | select (.state == "SKIPPED") | .name' | wc -l)
+  if [[ "$skipped_jobs" -gt 0 ]]; then
+    __sleep "💤 ... Waiting for skipped jobs to potentially fire"
+  fi
+}
+
 __label_if_bot() {
   local pr_number=$1
   if [[ -n "$GH_MERGE_TRAIN_BOT_LABEL" ]]; then
-    if __is_bot "$pr_number"; then
-      echo "ℹ️ Applying label $GH_MERGE_TRAIN_BOT_LABEL"
-      gh pr edit "$pr_number" --add-label "$GH_MERGE_TRAIN_BOT_LABEL"
+    if __is_valid_label "$GH_MERGE_TRAIN_BOT_LABEL"; then
+      if __is_bot "$pr_number"; then
+        echo "ℹ️ Applying label $GH_MERGE_TRAIN_BOT_LABEL"
+        gh pr edit "$pr_number" --add-label "$GH_MERGE_TRAIN_BOT_LABEL"
+        # If there are skipped jobs, then labelling may start them, so give it a chance.
+        __wait_if_skipped_jobs "$pr_number"
+      fi
     fi
   fi
 }
@@ -298,6 +321,7 @@ __update_branch() {
       continue
     fi
     echo "ℹ️ Working on $url"
+    __label_if_bot "$pr"
     if [[ ! $(__merge_status "$pr") =~ ^(CLEAN|BLOCKED)$ ]]; then
       if ! __update_branch "$pr"; then
         echo "⚠️ last attempt to merge"
@@ -308,7 +332,6 @@ __update_branch() {
       # sad but sometimes the checks don't start quick enough
       __sleep "💤... Waiting for checks to fire."
     fi
-    __label_if_bot "$pr"
     if [[ "$GH_MERGE_TRAIN_RETRY_FAILED_JOBS" == "true" ]]; then
       __wait_with_retry "$pr"
     else


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

- `gh label list` gives us the labels on a repo so technically we should be able to list the labels and only apply if it exists
- also apply the label before we try to update the branch

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- only add label if it exists in repo
- applies bot label before doing an update-branch

<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->

```
GH_MERGE_TRAIN_BOT_LABEL=dependency_reviewed
GH_MERGE_TRAIN_DEPENDABOT_RECREATE=true
gh merge-train https://github.com/xxxxx/pull/1234 https://github.com/xxxxxx/pull/5678
🏷️ label_to_find not found in repo for https://github.com/xxxxxx/pull/1234
🔎 ... waiting for checks to complete using gh pr checks
All checks were successful
0 cancelled, 0 failing, 3 successful, 8 skipped, and 0 pending checks
ℹ️ PR Authored by app/dependabot
✓ Approved pull request xxxxs#1234

ℹ️ Using Default Message
✓ Squashed and merged pull request...
✓ Deleted remote branch dependabot/....
💤...
ℹ️ Working on https://github.com/xxxxx/pull/5678
🏷️ label_to_find not found in repo for https://github.com/xxxxxx/pull/5678
ℹ️ Update branch using @dependabot recreate
https://github.com/xxxxx/pull/5678#issuecomment-4289797148
💤 Waiting on dependabot to catch up, 15 seconds...
💤 Waiting on dependabot to catch up, 15 seconds...
💤 Waiting on dependabot to catch up, 15 seconds...
💤 Waiting on dependabot to catch up, 15 seconds...
💤... Waiting for checks to fire.
🔎 ... waiting for checks to complete using gh pr checks
All checks were successful
...
```
