### PR TITLE
feat: detect current-branch PR or usage if no-args

### DIFF
--- a/gh-merge-train
+++ b/gh-merge-train
@@ -28,6 +28,9 @@ Usage: gh merge-train [flags] [pr...]
 
 This is a fake merge train that rebases, approves, and squash-merges each argument
 
+If no <pr> is supplied the PR for the current branch is used.
+Terminates with a warning if the current branch is the default branch.
+
 In effect it takes some toil out of your life because we end up with this:
 
 gh-merge-train 25 26 27
@@ -93,6 +96,22 @@ __pr_view_field() {
 __merge_status() {
   local pr_number=$1
   __pr_view_field mergeStateStatus "$pr_number"
+}
+
+__current_branch_pr() {
+  local current default pr_number
+  current=$(git branch --show-current)
+  default=$(gh repo view --json defaultBranchRef --jq ".defaultBranchRef.name")
+  if [[ "$current" == "$default" ]]; then
+    echo "⚠️ on default branch, cannot determine PR" >&2
+    exit 1
+  fi
+  pr_number=$(gh pr view --json number --jq ".number" 2>/dev/null || true)
+  if [[ -z "$pr_number" ]]; then
+    echo "⚠️ no PR found for current branch" >&2
+    exit 1
+  fi
+  echo "$pr_number"
 }
 
 __extract_squash_merge_message() {
@@ -317,9 +336,12 @@ __update_branch() {
     esac
   done
   if [[ "$#" -eq 0 ]]; then
+    mapfile -t _prs < <(__current_branch_pr)
+    set -- "${_prs[@]}"
+  fi
+  if [[ "$#" -eq 0 ]]; then
     usage
   fi
-
   first="true"
 
   for pr in "$@"; do

--- a/gh-merge-train
+++ b/gh-merge-train
@@ -14,6 +14,7 @@ GH_MERGE_TRAIN_BOT_LABEL=${GH_MERGE_TRAIN_BOT_LABEL:-}
 GH_MERGE_TRAIN_DEPENDABOT_REBASE=${GH_MERGE_TRAIN_DEPENDABOT_REBASE:-}
 GH_MERGE_TRAIN_DEPENDABOT_RECREATE=${GH_MERGE_TRAIN_DEPENDABOT_RECREATE:-}
 GH_MERGE_TRAIN_RETRY_FAILED_JOBS=${GH_MERGE_TRAIN_RETRY_FAILED_JOBS:-false}
+GH_MERGE_TRAIN_CURRENT_BRANCH=${GH_MERGE_TRAIN_CURRENT_BRANCH:-false}
 
 # Selects failed jobs from the status_rollup with some dodgy capturing
 # output to be {"runId":"24521981319","jobId":"71682061689"}
@@ -49,12 +50,13 @@ Flags
   -m, --merge merge rather than rebase when updating the pr branch
 
 env:
-  GH_POLL_INTERVAL_SECS             : interval between re-attempts            : [$POLL_INTERVAL_SECS]
-  GH_MERGE_TRAIN_MAX_ATTEMPTS       : how many times to attempt an update     : [$GH_MERGE_TRAIN_MAX_ATTEMPTS]
-  GH_MERGE_TRAIN_BOT_LABEL          : optional label to apply to a bot PR.    : [$GH_MERGE_TRAIN_BOT_LABEL]
-  GH_MERGE_TRAIN_DEPENDABOT_REBASE  : if 'true' use @dependabot rebase        : [$GH_MERGE_TRAIN_DEPENDABOT_REBASE]
-  GH_MERGE_TRAIN_DEPENDABOT_RECREATE: if 'true' use @dependabot recreate      : [$GH_MERGE_TRAIN_DEPENDABOT_RECREATE]
-  GH_MERGE_TRAIN_RETRY_FAILED_JOBS  : Because you have flaky jobs for reasons : [$GH_MERGE_TRAIN_RETRY_FAILED_JOBS]
+  GH_POLL_INTERVAL_SECS             : interval between re-attempts              : [$POLL_INTERVAL_SECS]
+  GH_MERGE_TRAIN_MAX_ATTEMPTS       : how many times to attempt an update       : [$GH_MERGE_TRAIN_MAX_ATTEMPTS]
+  GH_MERGE_TRAIN_BOT_LABEL          : optional label to apply to a bot PR.      : [$GH_MERGE_TRAIN_BOT_LABEL]
+  GH_MERGE_TRAIN_DEPENDABOT_REBASE  : if 'true' use @dependabot rebase          : [$GH_MERGE_TRAIN_DEPENDABOT_REBASE]
+  GH_MERGE_TRAIN_DEPENDABOT_RECREATE: if 'true' use @dependabot recreate        : [$GH_MERGE_TRAIN_DEPENDABOT_RECREATE]
+  GH_MERGE_TRAIN_RETRY_FAILED_JOBS  : Because you have flaky jobs for reasons   : [$GH_MERGE_TRAIN_RETRY_FAILED_JOBS]
+  GH_MERGE_TRAIN_CURRENT_BRANCH     : merge train the current branch if no args : [$GH_MERGE_TRAIN_CURRENT_BRANCH]
 EOF
   exit "$exit"
 }
@@ -336,11 +338,12 @@ __update_branch() {
     esac
   done
   if [[ "$#" -eq 0 ]]; then
-    mapfile -t _prs < <(__current_branch_pr)
-    set -- "${_prs[@]}"
-  fi
-  if [[ "$#" -eq 0 ]]; then
-    usage
+    if [[ "$GH_MERGE_TRAIN_CURRENT_BRANCH" == "true" ]]; then
+      mapfile -t _prs < <(__current_branch_pr)
+      set -- "${_prs[@]}"
+    else
+      usage
+    fi
   fi
   first="true"
 


### PR DESCRIPTION
# Motivation
<!-- Why am I doing this -->

## Changes
<!-- Bits between these two tags can be used as the squash_merge_commit_message when the PR is
     approved and merged if you're using https://github.com/quotidian-ennui/gh-squash-merge -->
<!-- SQUASH_MERGE_START -->
- feat: detect current-branch PR or usage if no-args
- behaviour is behind GH_MERGE_TRAIN_CURRENT_BRANCH env
<!-- SQUASH_MERGE_END -->

## Testing
<!-- Testing Notes -->

Useful if you have repo with PRs waiting to be merged.

```
unset GH_MERGE_TRAIN_CURRENT_BRANCH
gh merge-train
# should print help
export GH_MERGE_TRAIN_CURRENT_BRANCH=true
gh merge-train
# will now try to merge it.
```

- opted for an environment variable feature flag because this is 'more backwards compatible'